### PR TITLE
add: publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,40 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.1.7
+
+-    Add: publishing workflow
+
 # 1.1.6
 
 -    Add: svg compression option (enabled by default). Compression removes spaces between tags and line breaks

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='1.1.6',
+    version='1.1.7',
     author='Daniil Minukhin',
     author_email='ddddsa@gmail.com',
     url='https://github.com/foliant-docs/foliantcontrib.graphviz',


### PR DESCRIPTION

---
## EntelligenceAI PR Summary 
 This PR adds automated Python package publishing to PyPI via GitHub Actions workflow.
- Created new workflow file `.github/workflows/python-publish.yml` with release publication and manual dispatch triggers
- Configured Python 3.x environment setup and build dependency installation
- Implemented distribution package creation using the `build` module
- Integrated PyPI publishing using official PyPA action with token-based authentication
- Applied security best practices with read-only content permissions and pinned action versions (checkout@v3, setup-python@v3, and specific commit SHA for publish action) 

